### PR TITLE
npm build and publish pipeline

### DIFF
--- a/.tekton/npm-task.yaml
+++ b/.tekton/npm-task.yaml
@@ -1,28 +1,36 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: yarn
+  name: npm
 spec:
-  description: Run yarn tasks
-  params:
-    - default: .
-      description: The path where package.json of the project is defined.
-      name: PATH_CONTEXT
-      type: string
-    - default: install
-      description: The yarn script you want to run.
-      name: SCRIPT
-      type: string
-    - default: 'registry.redhat.io/rhel9/nodejs-20:latest'
-      description: The node image you want to use.
-      name: IMAGE
-      type: string
-  steps:
-    - computeResources: {}
-      image: $(params.IMAGE)
-      name: yarn
-      script: |
-        npm install --global yarn && yarn $(params.SCRIPT)
-      workingDir: $(workspaces.source.path)/$(params.PATH_CONTEXT)
+  description: Run npm tasks
+
   workspaces:
     - name: source
+    - name: npmrc
+      optional: true
+
+  params:
+
+    - name: PATH_CONTEXT
+      type: string
+      default: .
+      description: The path where package.json of the project is defined
+    - name: COMMAND
+      type: string
+      default: npm install
+      description: The script you want to run
+    - name: IMAGE
+      type: string
+      default: 'registry.redhat.io/rhel9/nodejs-20:latest'
+      description: The node image you want to use
+
+  steps:
+
+    - name: npm
+      image: $(params.IMAGE)
+      script: |
+        if [ -f $(workspaces.npmrc.path)/.npmrc ]; then
+          cp $(workspaces.npmrc.path)/.npmrc ~/.npmrc
+        fi && npm $(params.COMMAND)
+      workingDir: $(workspaces.source.path)/$(params.PATH_CONTEXT)

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -4,7 +4,9 @@ metadata:
   name: rhdh-plugin
 spec:
   workspaces:
-  - name: source
+    - name: source
+    - name: npmrc
+      optional: true
 
   params:
 
@@ -14,16 +16,10 @@ spec:
     - name: GIT_REVISION
       type: string
       default: main
-    - name: APP_NAME
-      description: The name of the application
-      default: 'nodejs-app'      
-    - name: APP_VERSION
-      description: The version of the application
-      default: '1.0'      
 
   tasks:
 
-  - name: clone
+  - name: git-clone
     taskRef:
       name: git-clone
       kind: ClusterTask
@@ -33,18 +29,33 @@ spec:
       - name: revision
         value: $(params.GIT_REVISION)
     workspaces:
-    - name: output
-      workspace: source
+      - name: output
+        workspace: source
 
-  - name: yarn-build
+  - name: yarn-install
     taskRef:
-      name: yarn
+      name: npm
       kind: Task
     runAfter: 
-      - clone
+      - git-clone
     params:
-    - name: SCRIPT
-      value: install
+      - name: COMMAND
+        value: install --global yarn && yarn install
     workspaces:
-    - name: source
-      workspace: source
+      - name: source
+        workspace: source
+
+  - name: publish-package
+    taskRef:
+      name: npm
+      kind: Task
+    runAfter:
+      - yarn-install
+    params:
+      - name: COMMAND
+        value: publish
+    workspaces:
+      - name: source
+        workspace: source
+      - name: npmrc
+        workspace: npmrc


### PR DESCRIPTION
Pipeline steps:

- git clone ...
- npm install --global yarn && yarn install
- npm publish

Bind the optional npmrc workspace to a secret that looks like the one below for registry authentication.
```
kind: Secret
apiVersion: v1
metadata:
  name: npmrc
stringData:
  .npmrc: |
    //npm.pkg.github.com/:_authToken=$GITHUB_TOKEN
    @$GITHUB_ORG:registry=https://npm.pkg.github.com
type: Opaque
```